### PR TITLE
Use specific Tractive Client identifier for this integration

### DIFF
--- a/TractiveGpsIO/module.php
+++ b/TractiveGpsIO/module.php
@@ -265,7 +265,7 @@ class TractiveGpsIO extends IPSModule
             $header = [
                 'content-type: application/json;charset=UTF-8',
                 'accept: application/json, text/plain, */*',
-                'x-tractive-client: 5728aa1fc9077f7c32000186',
+                'x-tractive-client: 6671ac0e3c527688feb5fe80',
             ];
             $postdata = [
                 'platform_email' => $user,
@@ -577,7 +577,7 @@ class TractiveGpsIO extends IPSModule
             'content-type: application/json;charset=UTF-8',
             'accept: application/json, text/plain, */*',
             'authorization: Bearer ' . $access_token,
-            'x-tractive-client: 5728aa1fc9077f7c32000186',
+            'x-tractive-client: 6671ac0e3c527688feb5fe80',
             'x-tractive-user: ' . $user_id,
         ];
 


### PR DESCRIPTION
This allows Tractive to better understand traffic sources of the API requests observed on their services.

The specific Tractive Client key was created by Tractive specifically for the IP Symcon integration at https://github.com/demel42/IPSymconTractiveGPS

Note: This contribution is made in an individual capacity and does not imply any official or unofficial endorsement or support of this project by Tractive. My participation is solely aimed at improving the integration or utilization of his project, and it should not be interpreted as a partnership or confirmation of the project's reliability or security.